### PR TITLE
Clarify skip-notification action semantics

### DIFF
--- a/app/src/main/java/com/micoyc/speakthat/rules/ActionConfigActivity.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/ActionConfigActivity.kt
@@ -53,7 +53,7 @@ class ActionConfigActivity : AppCompatActivity() {
 
     private fun setupUI() {
         if (actionType == ActionType.DISABLE_SPEAKTHAT) {
-            setupDisableSpeakThatUI()
+            setupSkipNotificationUI()
         } else {
             InAppLogger.logError("ActionConfigActivity", "Unknown action type: $actionType")
             finish()
@@ -63,7 +63,7 @@ class ActionConfigActivity : AppCompatActivity() {
         binding.btnCancel.setOnClickListener { finish() }
     }
 
-    private fun setupDisableSpeakThatUI() {
+    private fun setupSkipNotificationUI() {
         binding.cardDisableSpeakThat.visibility = View.VISIBLE
         binding.textDisableSpeakThatInfo.text = getString(com.micoyc.speakthat.R.string.action_disable_description)
     }
@@ -73,7 +73,7 @@ class ActionConfigActivity : AppCompatActivity() {
     }
 
     private fun saveAction() {
-        val action = createDisableSpeakThatAction()
+        val action = createSkipNotificationAction()
 
         val resultIntent = android.content.Intent().apply {
             putExtra(RESULT_ACTION, action.toJson())
@@ -85,7 +85,7 @@ class ActionConfigActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun createDisableSpeakThatAction(): Action {
+    private fun createSkipNotificationAction(): Action {
         return if (isEditing && originalAction != null) {
             originalAction!!.copy(
                 description = "Skip this notification"
@@ -104,4 +104,3 @@ class ActionConfigActivity : AppCompatActivity() {
         return true
     }
 }
-

--- a/app/src/main/java/com/micoyc/speakthat/rules/ActionExecutor.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/ActionExecutor.kt
@@ -1,7 +1,6 @@
 package com.micoyc.speakthat.rules
 
 import android.content.Context
-import android.content.SharedPreferences
 import com.micoyc.speakthat.InAppLogger
 
 /**
@@ -13,10 +12,7 @@ class ActionExecutor(private val context: Context) {
     
     companion object {
         private const val TAG = "ActionExecutor"
-        private const val PREFS_NAME = "SpeakThatPrefs"
     }
-    
-    private val sharedPreferences: SharedPreferences = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
     
     /**
      * Execute a list of actions
@@ -44,34 +40,31 @@ class ActionExecutor(private val context: Context) {
         
         InAppLogger.logDebug(TAG, "Executing action: ${action.getLogMessage()}")
         
-        return executeDisableSpeakThat(action)
+        return executeSkipNotification(action)
     }
     
     // ============================================================================
     // ACTION IMPLEMENTATIONS
     // ============================================================================
     
-    private fun executeDisableSpeakThat(action: Action): ActionExecutionResult {
+    private fun executeSkipNotification(action: Action): ActionExecutionResult {
         try {
-            // Set the main SpeakThat toggle to disabled
-            sharedPreferences.edit().putBoolean("speakthat_enabled", false).apply()
-            
-            InAppLogger.logDebug(TAG, "SpeakThat disabled via rule action")
+            InAppLogger.logDebug(TAG, "Skip notification action executed (no global state changes)")
             
             return ActionExecutionResult(
                 actionId = action.id,
                 actionType = action.type,
                 success = true,
-                message = "SpeakThat disabled"
+                message = "Notification skipped"
             )
             
         } catch (e: Throwable) {
-            InAppLogger.logError(TAG, "Error disabling SpeakThat: ${e.message}")
+            InAppLogger.logError(TAG, "Error skipping notification: ${e.message}")
             return ActionExecutionResult(
                 actionId = action.id,
                 actionType = action.type,
                 success = false,
-                message = "Failed to disable SpeakThat: ${e.message}"
+                message = "Failed to skip notification: ${e.message}"
             )
         }
     }

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleData.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleData.kt
@@ -254,7 +254,7 @@ enum class TriggerType(val displayName: String, val description: String) {
  * Types of actions that can be performed when a rule is triggered
  */
 enum class ActionType(val displayName: String, val description: String) {
-    DISABLE_SPEAKTHAT("Skip this notification", "Don't read this notification aloud");
+    DISABLE_SPEAKTHAT("Skip this notification", "Skip reading this notification without changing global settings");
     
     companion object {
         fun fromDisplayName(name: String): ActionType {

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleManager.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleManager.kt
@@ -296,14 +296,14 @@ class RuleManager(private val context: Context) {
             // Execute actions for all rules that should execute
             executeActionsForRules(executingRules)
             
-            // Check if any of the executing rules contain DISABLE_SPEAKTHAT actions
+            // Check if any of the executing rules contain skip-notification actions
             val shouldBlock = executingRules.any { ruleResult ->
                 val rule = getRule(ruleResult.ruleId)
                 val hasDisableAction = rule?.actions?.any { action ->
                     action.enabled && action.type == ActionType.DISABLE_SPEAKTHAT
                 } ?: false
                 
-                InAppLogger.logDebug(TAG, "Rule '${ruleResult.ruleName}' has DISABLE_SPEAKTHAT action: $hasDisableAction")
+                InAppLogger.logDebug(TAG, "Rule '${ruleResult.ruleName}' has skip-notification action: $hasDisableAction")
                 hasDisableAction
             }
             

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleSystemTest.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleSystemTest.kt
@@ -97,7 +97,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat"
+                    description = "Skip this notification"
                 )
             ),
             triggerLogic = LogicGate.AND
@@ -126,7 +126,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat when screen is off"
+                    description = "Skip this notification when screen is off"
                 )
             ),
             triggerLogic = LogicGate.AND
@@ -219,7 +219,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat in car"
+                    description = "Skip this notification in car"
                 )
             ),
             triggerLogic = LogicGate.AND
@@ -260,7 +260,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat during night mode"
+                    description = "Skip this notification during night mode"
                 ),
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
@@ -331,7 +331,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat"
+                    description = "Skip this notification"
                 )
             )
         )
@@ -341,7 +341,7 @@ class RuleSystemTest(private val context: Context) {
     
     /**
      * Test the fix for the blocking logic bug
-     * This test verifies that only rules with DISABLE_SPEAKTHAT actions block notifications
+     * This test verifies that only rules with skip-notification actions block notifications
      */
     fun testBlockingLogicFix() {
         InAppLogger.logDebug(TAG, "Test 8: Blocking logic fix verification")
@@ -356,7 +356,7 @@ class RuleSystemTest(private val context: Context) {
         // Enable the rules system
         AutomationModeManager(context).setMode(AutomationMode.CONDITIONAL_RULES)
         
-        // Test 1: Rule with DISABLE_SPEAKTHAT action should block
+        // Test 1: Rule with skip-notification action should block
         val blockingRule = Rule(
             name = "Blocking Rule",
             enabled = true,
@@ -370,7 +370,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat"
+                    description = "Skip this notification"
                 )
             )
         )
@@ -438,7 +438,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat when no headphones"
+                    description = "Skip this notification when no headphones"
                 )
             ),
             triggerLogic = LogicGate.AND
@@ -462,7 +462,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat when screen is on"
+                    description = "Skip this notification when screen is on"
                 )
             ),
             triggerLogic = LogicGate.AND
@@ -497,7 +497,7 @@ class RuleSystemTest(private val context: Context) {
             actions = listOf(
                 Action(
                     type = ActionType.DISABLE_SPEAKTHAT,
-                    description = "Disable SpeakThat during work hours when not on home WiFi"
+                    description = "Skip this notification during work hours when not on home WiFi"
                 )
             ),
             triggerLogic = LogicGate.AND,

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1205,7 +1205,7 @@ This permission is completely optional; SpeakThat! will still function without i
 
     <!-- Action Configuration -->
     <string name="action_disable_speakthat">Skip this notification</string>
-    <string name="action_disable_description">SpeakThat will not read this notification.</string>
+    <string name="action_disable_description">SpeakThat will not read this notification and will not change any global settings.</string>
     <string name="action_enable_app_filter">Enable App Filter</string>
     <string name="action_enable_app_description">Select which app to enable filtering for:</string>
     <string name="action_select_app">Select App</string>


### PR DESCRIPTION
### Motivation

- Fix dangerous semantics where the rule action labeled “Skip this notification” actually toggled the global SpeakThat enable switch.
- Ensure conditional rule actions affect only the current notification lifecycle and do not mutate global settings.
- Align UI wording, logs, and tests with the corrected semantics to avoid user confusion.

### Description

- Change `ActionExecutor` to no longer modify shared preferences or global state and implement `executeSkipNotification` that returns a skip result without side effects.
- Update `ActionType` description to clarify `DISABLE_SPEAKTHAT` means “Skip this notification” and explicitly note it does not change global settings in `RuleData.kt` and `strings.xml`.
- Rename and adjust UI helper methods in `ActionConfigActivity` to `setupSkipNotificationUI`, `createSkipNotificationAction`, and update the saved action payload description to use “Skip this notification”.
- Update `RuleManager` logging to refer to “skip-notification” actions and refresh rule system test strings in `RuleSystemTest.kt` to match the corrected semantics.

### Testing

- No automated test suite was executed as part of this change (no test runner invoked).
- Existing rule system test file `RuleSystemTest.kt` was updated (text/description changes) but not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69693c8b09bc8327a737fedcbe85ef21)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns action semantics so rule-based "skip" affects only the current notification.
> 
> - ActionExecutor: replace global toggle with `executeSkipNotification` (no SharedPreferences writes); updates success/error messages
> - ActionConfigActivity: rename helpers to `setupSkipNotificationUI`/`createSkipNotificationAction`; keep description "Skip this notification"
> - RuleData/strings: clarify `ActionType.DISABLE_SPEAKTHAT` description to explicitly not change global settings
> - RuleManager: logging now refers to skip-notification actions; blocking logic unchanged but terminology clarified
> - RuleSystemTest: update action descriptions and comments to reflect skip semantics
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 297165ab77ab44bbc9f87fd70d1480e151b82b88. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->