### PR TITLE
Add NotificationContext and thread it through rule evaluation pipeline

### DIFF
--- a/app/src/main/java/com/micoyc/speakthat/rules/NotificationContext.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/NotificationContext.kt
@@ -1,0 +1,27 @@
+package com.micoyc.speakthat.rules
+
+/**
+ * Notification-scoped context used for rule evaluation.
+ */
+data class NotificationContext(
+    val packageName: String,
+    val appLabel: String,
+    val notificationTitle: String?,
+    val notificationText: String?,
+    val notificationCategory: String?,
+    val notificationChannelId: String?,
+    val metadata: Map<String, Any?> = emptyMap()
+) {
+    companion object {
+        fun empty(): NotificationContext {
+            return NotificationContext(
+                packageName = "",
+                appLabel = "",
+                notificationTitle = null,
+                notificationText = null,
+                notificationCategory = null,
+                notificationChannelId = null
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleData.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleData.kt
@@ -241,7 +241,8 @@ enum class TriggerType(val displayName: String, val description: String) {
     BLUETOOTH_DEVICE("Bluetooth Device Connected", "When a specific Bluetooth device is connected"),
     SCREEN_STATE("Screen State (On/Off)", "When the screen is on or off"),
     TIME_SCHEDULE("Time Schedule", "During specific time periods"),
-    WIFI_NETWORK("WiFi Network Connected", "When connected to a specific WiFi network");
+    WIFI_NETWORK("WiFi Network Connected", "When connected to a specific WiFi network"),
+    NOTIFICATION_PACKAGE("Notification Package", "When the notification is from a specific package");
     
     companion object {
         fun fromDisplayName(name: String): TriggerType {
@@ -270,7 +271,8 @@ enum class ExceptionType(val displayName: String, val description: String) {
     BLUETOOTH_DEVICE("Bluetooth Device Connected", "When a specific Bluetooth device is connected"),
     SCREEN_STATE("Screen State (On/Off)", "When the screen is on or off"),
     TIME_SCHEDULE("Time Schedule", "During specific time periods"),
-    WIFI_NETWORK("WiFi Network Connected", "When connected to a specific WiFi network");
+    WIFI_NETWORK("WiFi Network Connected", "When connected to a specific WiFi network"),
+    NOTIFICATION_PACKAGE("Notification Package", "When the notification is from a specific package");
     
     companion object {
         fun fromDisplayName(name: String): ExceptionType {

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleSystemTest.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleSystemTest.kt
@@ -17,6 +17,14 @@ class RuleSystemTest(private val context: Context) {
     }
     
     private val ruleManager = RuleManager(context)
+    private val notificationContext = NotificationContext(
+        packageName = "com.micoyc.speakthat.test",
+        appLabel = "SpeakThat Test",
+        notificationTitle = "Test Notification",
+        notificationText = "Test notification text",
+        notificationCategory = "test",
+        notificationChannelId = "test_channel"
+    )
     
     /**
      * Run comprehensive tests of the rule system
@@ -295,7 +303,7 @@ class RuleSystemTest(private val context: Context) {
         InAppLogger.logDebug(TAG, "Total rules: ${allRules.size}")
         
         // Evaluate all rules
-        val evaluationResults = ruleManager.evaluateAllRules()
+        val evaluationResults = ruleManager.evaluateAllRules(notificationContext)
         InAppLogger.logDebug(TAG, "Evaluation results: ${evaluationResults.size}")
         
         evaluationResults.forEach { result ->
@@ -303,8 +311,8 @@ class RuleSystemTest(private val context: Context) {
         }
         
         // Check if any rules should block notifications
-        val shouldBlock = ruleManager.shouldBlockNotification()
-        val blockingRules = ruleManager.getBlockingRuleNames()
+        val shouldBlock = ruleManager.shouldBlockNotification(notificationContext)
+        val blockingRules = ruleManager.getBlockingRuleNames(notificationContext)
         
         InAppLogger.logDebug(TAG, "Should block notifications: $shouldBlock")
         InAppLogger.logDebug(TAG, "Blocking rules: $blockingRules")
@@ -397,8 +405,8 @@ class RuleSystemTest(private val context: Context) {
         ruleManager.addRule(nonBlockingRule)
         
         // Evaluate the rules
-        val shouldBlock = ruleManager.shouldBlockNotification()
-        val blockingRules = ruleManager.getBlockingRuleNames()
+        val shouldBlock = ruleManager.shouldBlockNotification(notificationContext)
+        val blockingRules = ruleManager.getBlockingRuleNames(notificationContext)
         
         InAppLogger.logDebug(TAG, "Blocking logic test results:")
         InAppLogger.logDebug(TAG, "- Should block notifications: $shouldBlock")
@@ -613,8 +621,8 @@ class RuleSystemTest(private val context: Context) {
      */
     fun getTestSummary(): String {
         val stats = ruleManager.getRuleStats()
-        val shouldBlock = ruleManager.shouldBlockNotification()
-        val blockingRules = ruleManager.getBlockingRuleNames()
+        val shouldBlock = ruleManager.shouldBlockNotification(notificationContext)
+        val blockingRules = ruleManager.getBlockingRuleNames(notificationContext)
         
         return """
             Rule System Test Summary:

--- a/app/src/main/java/com/micoyc/speakthat/rules/RuleTemplates.kt
+++ b/app/src/main/java/com/micoyc/speakthat/rules/RuleTemplates.kt
@@ -143,6 +143,7 @@ object RuleTemplates {
                     emptyMap<String, Any>()
                 }
             }
+            TriggerType.NOTIFICATION_PACKAGE -> data
             else -> data
         }
     }


### PR DESCRIPTION
### Motivation

- Provide a notification-scoped context so rules can evaluate conditions that depend on notification fields (package, title, text, category, channel, metadata).
- Allow future rule triggers/exceptions to read notification details instead of relying on external globals or ad-hoc plumbing.

### Description

- Add `NotificationContext` data class with package name, app label, title/text, category, channel id and metadata at `rules/NotificationContext.kt`.
- Introduce `NOTIFICATION_PACKAGE` trigger/exception types and a placeholder evaluator that matches configured package(s) against `NotificationContext.packageName` in `RuleData.kt` and `RuleEvaluator.kt` (functions: `evaluateNotificationPackageTrigger`, `evaluateNotificationPackageException`, and `evaluateNotificationPackageCondition`).
- Thread `NotificationContext` through the rules pipeline by changing `RuleEvaluator.evaluateRule(...)` to accept the context, and updating `evaluateTriggers`, `evaluateTrigger`, `evaluateExceptions`, and `evaluateException` to pass the context through evaluation paths.
- Update `RuleManager` to accept a `NotificationContext` in `evaluateAllRules`, `shouldBlockNotification`, and `getBlockingRuleNames`, add `lastEvaluationContext` to the evaluation cache, and pass the context into `RuleEvaluator`.
- Build and pass a `NotificationContext` from `NotificationReaderService.applyConditionalFiltering(...)` (constructed from the `StatusBarNotification` and filtered text) into the `RuleManager` calls, and updated template processing and tests (`RuleTemplates.kt`, `RuleSystemTest.kt`) to validate wiring.

### Testing

- No automated tests were executed as part of this change; `RuleSystemTest` was updated to create and use a `NotificationContext` but not run here.
- The change is limited to wiring and adding a placeholder notification-package evaluator; further unit/integration tests should be run in CI to validate behavior under runtime conditions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6969422c61b883278bcc36b859eb95d6)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a notification-scoped context to enable context-aware rule evaluation and filtering.
> 
> - New `rules/NotificationContext` with package/app label/title/text/category/channel/metadata
> - Threaded through `RuleEvaluator` (`evaluateRule`, triggers/exceptions) and `RuleManager` (`evaluateAllRules`, `shouldBlockNotification`, `getBlockingRuleNames`) with evaluation cache keyed by context
> - `NotificationReaderService.applyConditionalFiltering` now builds/passes `NotificationContext` (using `StatusBarNotification`) to rules
> - Added `NOTIFICATION_PACKAGE` trigger/exception in `RuleData` and evaluators in `RuleEvaluator` (`evaluateNotificationPackageTrigger/Exception/Condition`)
> - Updated tests/templates: `RuleSystemTest` uses context; `RuleTemplates` passes through data for notification-package rules
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a39dbc2e8dabe671038f9696ccdbfcc5228e670. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->