### PR TITLE
Option to omit repeated "prefix" of a previously-read notification

### DIFF
--- a/app/src/main/java/com/micoyc/speakthat/FilterConfigManager.java
+++ b/app/src/main/java/com/micoyc/speakthat/FilterConfigManager.java
@@ -162,6 +162,7 @@ public class FilterConfigManager {
         public boolean honourAudioMode; // Legacy combined audio mode flag
         public boolean persistentNotification; // Add persistent notification setting
         public boolean notificationWhileReading; // Add notification while reading setting
+        public boolean skipRepeatedNotificationPrefix;
         public boolean waveToStopEnabled;
         public int waveTimeoutSeconds;
         public long waveHoldDurationMs; // Wave hold duration in milliseconds
@@ -197,6 +198,7 @@ public class FilterConfigManager {
             this.honourAudioMode = true; // Legacy: keep for backwards compatibility
             this.persistentNotification = false; // Default to false
             this.notificationWhileReading = false; // Default to false
+            this.skipRepeatedNotificationPrefix = false; // Default to false
             this.waveToStopEnabled = false;
             this.waveTimeoutSeconds = 30;
             this.waveHoldDurationMs = 150; // Default wave hold duration
@@ -399,6 +401,7 @@ public class FilterConfigManager {
         config.behavior.honourAudioMode = legacyHonourAudioMode;
         config.behavior.persistentNotification = prefs.getBoolean("persistent_notification", false); // Add persistent notification
         config.behavior.notificationWhileReading = prefs.getBoolean("notification_while_reading", false); // Add notification while reading
+        config.behavior.skipRepeatedNotificationPrefix = prefs.getBoolean("skip_notification_repeated_prefix", false);
         config.behavior.waveToStopEnabled = prefs.getBoolean("wave_to_stop_enabled", false);
         config.behavior.waveTimeoutSeconds = prefs.getInt("wave_timeout_seconds", 30);
         config.behavior.waveHoldDurationMs = prefs.getInt("wave_hold_duration_ms", 150); // Read as int, auto-converts to long
@@ -504,6 +507,7 @@ public class FilterConfigManager {
         behavior.put("honourAudioMode", config.behavior.honourAudioMode); // Legacy combined flag
         behavior.put("persistentNotification", config.behavior.persistentNotification); // Add persistent notification
         behavior.put("notificationWhileReading", config.behavior.notificationWhileReading); // Add notification while reading
+        behavior.put("skipRepeatedNotificationPrefix", config.behavior.skipRepeatedNotificationPrefix);
         behavior.put("waveToStopEnabled", config.behavior.waveToStopEnabled);
         behavior.put("waveTimeoutSeconds", config.behavior.waveTimeoutSeconds);
         behavior.put("waveHoldDurationMs", (int) config.behavior.waveHoldDurationMs); // Cast long to int for JSON
@@ -1026,6 +1030,11 @@ public class FilterConfigManager {
                 
                 if (behavior.has("notificationWhileReading")) {
                     mainEditor.putBoolean("notification_while_reading", behavior.getBoolean("notificationWhileReading"));
+                    totalImported++;
+                }
+
+                if (behavior.has("skipRepeatedNotificationPrefix")) {
+                    mainEditor.putBoolean("skip_notification_repeated_prefix", behavior.getBoolean("skipRepeatedNotificationPrefix"));
                     totalImported++;
                 }
                 

--- a/app/src/main/java/com/micoyc/speakthat/NotificationReaderService.kt
+++ b/app/src/main/java/com/micoyc/speakthat/NotificationReaderService.kt
@@ -70,6 +70,7 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
     private var isCurrentlySpeaking = false
     private var isTemporaryVoiceOverrideActive = false
     private var currentSpeechText = ""
+    private var lastFullNotificationSpeechText: String? = null
     private var currentAppName = ""
     private var currentOriginalAppName = "" // Store original app name for statistics (before privacy modification)
     private var currentTtsText = ""
@@ -96,6 +97,7 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
     private var contentCapTimeLimit = DEFAULT_CONTENT_CAP_TIME_LIMIT
     private var priorityApps: Set<String> = emptySet()
     private var notificationBehavior = "interrupt"
+    private var skipRepeatedNotificationPrefix = false
     private var mediaBehavior = "ignore"
     private var duckingVolume = 30
     private var duckingFallbackStrategy = "manual"
@@ -357,6 +359,7 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
                 // Behavior settings
         private const val KEY_NOTIFICATION_BEHAVIOR = "notification_behavior"
         private const val KEY_PRIORITY_APPS = "priority_apps"
+        private const val KEY_SKIP_REPEATED_NOTIFICATION_PREFIX = "skip_notification_repeated_prefix"
         
         // Media behavior settings
         private const val KEY_MEDIA_BEHAVIOR = "media_behavior"
@@ -3119,7 +3122,8 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
         // Load behavior settings  
         notificationBehavior = sharedPreferences?.getString(KEY_NOTIFICATION_BEHAVIOR, "interrupt") ?: "interrupt"
         priorityApps = HashSet(sharedPreferences?.getStringSet(KEY_PRIORITY_APPS, HashSet()) ?: HashSet())
-        
+        skipRepeatedNotificationPrefix = sharedPreferences?.getBoolean(KEY_SKIP_REPEATED_NOTIFICATION_PREFIX, false) ?: false
+
         // Load media behavior settings
         mediaBehavior = sharedPreferences?.getString(KEY_MEDIA_BEHAVIOR, "ignore") ?: "ignore"
         duckingVolume = sharedPreferences?.getInt(KEY_DUCKING_VOLUME, 30) ?: 30
@@ -6213,10 +6217,12 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
             formatSpeechText(appName, text, packageName, sbn, speechTemplateOverride)
         }
 
+        val collapsedSpeechText = collapseRepeatedNotificationPrefix(speechText)
+        lastFullNotificationSpeechText = speechText
         val tidySpeechText = if (tidySpeechRemoveEmojisEnabled) {
-            removeSpokenEmojis(speechText)
+            removeSpokenEmojis(collapsedSpeechText)
         } else {
-            speechText
+            collapsedSpeechText
         }
         
         // Determine which delay to use (conditional delay overrides global delay)
@@ -7032,6 +7038,12 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
                 priorityApps = HashSet(sharedPreferences?.getStringSet(KEY_PRIORITY_APPS, HashSet()) ?: HashSet())
                 Log.d(TAG, "Behavior settings updated - mode: $notificationBehavior, priority apps: ${priorityApps.size}")
             }
+            KEY_SKIP_REPEATED_NOTIFICATION_PREFIX -> {
+                // Reload repeated prefix skip setting
+                skipRepeatedNotificationPrefix = sharedPreferences?.getBoolean(KEY_SKIP_REPEATED_NOTIFICATION_PREFIX, false) ?: false
+                Log.d(TAG, "Skip repeated prefix notification setting updated: $skipRepeatedNotificationPrefix")
+                InAppLogger.log("Service", "Skip repeated prefix notification setting updated: $skipRepeatedNotificationPrefix")
+            }
             KEY_MEDIA_BEHAVIOR, KEY_DUCKING_VOLUME, KEY_DUCKING_FALLBACK_STRATEGY -> {
                 // Reload media behavior settings
                 mediaBehavior = sharedPreferences?.getString(KEY_MEDIA_BEHAVIOR, "ignore") ?: "ignore"
@@ -7324,6 +7336,34 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
 
         
         return processedTemplate.trim()
+    }
+
+    private fun collapseRepeatedNotificationPrefix(fullText: String): String {
+        if (!skipRepeatedNotificationPrefix) {
+            return fullText
+        }
+        val previousText = lastFullNotificationSpeechText?.trim() ?: return fullText
+        val currentText = fullText.trim()
+        if (previousText.isEmpty() || currentText.isEmpty()) {
+            return fullText
+        }
+
+        val previousWords = previousText.split("\\s+".toRegex())
+        val currentWords = currentText.split("\\s+".toRegex())
+        val commonWords = minOf(previousWords.size, currentWords.size)
+        var samePrefixCount = 0
+        while (samePrefixCount < commonWords &&
+            previousWords[samePrefixCount].equals(currentWords[samePrefixCount], ignoreCase = true)
+        ) {
+            samePrefixCount++
+        }
+
+        if (samePrefixCount < 2) {
+            return fullText
+        }
+
+        val trimmed = currentWords.subList(samePrefixCount, currentWords.size).joinToString(" ")
+        return if (trimmed.isBlank()) fullText else trimmed
     }
 
     /**

--- a/app/src/main/java/com/micoyc/speakthat/NotificationReaderService.kt
+++ b/app/src/main/java/com/micoyc/speakthat/NotificationReaderService.kt
@@ -7358,7 +7358,7 @@ class NotificationReaderService : NotificationListenerService(), TextToSpeech.On
             samePrefixCount++
         }
 
-        if (samePrefixCount < 2) {
+        if (samePrefixCount < 1) {
             return fullText
         }
 

--- a/app/src/main/java/com/micoyc/speakthat/settings/BehaviorSettingsStore.java
+++ b/app/src/main/java/com/micoyc/speakthat/settings/BehaviorSettingsStore.java
@@ -19,6 +19,7 @@ public class BehaviorSettingsStore {
     public static final String KEY_DARK_MODE = "dark_mode";
     public static final String KEY_NOTIFICATION_BEHAVIOR = "notification_behavior";
     public static final String KEY_PRIORITY_APPS = "priority_apps";
+    public static final String KEY_SKIP_REPEATED_NOTIFICATION_PREFIX = "skip_notification_repeated_prefix";
     public static final String KEY_SHAKE_TO_STOP_ENABLED = "shake_to_stop_enabled";
     public static final String KEY_SHAKE_THRESHOLD = "shake_threshold";
     public static final String KEY_SHAKE_TIMEOUT_SECONDS = "shake_timeout_seconds";
@@ -82,6 +83,7 @@ public class BehaviorSettingsStore {
     public static final boolean DEFAULT_HONOUR_SILENT_MODE = true;
     public static final boolean DEFAULT_HONOUR_VIBRATE_MODE = true;
     public static final boolean DEFAULT_NOTIFICATION_DEDUPLICATION = false;
+    public static final boolean DEFAULT_SKIP_REPEATED_NOTIFICATION_PREFIX = false;
     public static final boolean DEFAULT_DISMISSAL_MEMORY_ENABLED = true;
     public static final int DEFAULT_DISMISSAL_MEMORY_TIMEOUT = 15;
     public static final int DEFAULT_WAVE_HOLD_DURATION_MS = 150;

--- a/app/src/main/java/com/micoyc/speakthat/settings/sections/NotificationBehaviorSection.java
+++ b/app/src/main/java/com/micoyc/speakthat/settings/sections/NotificationBehaviorSection.java
@@ -15,6 +15,7 @@ import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+import com.google.android.material.switchmaterial.SwitchMaterial;
 import com.micoyc.speakthat.AppPickerActivity;
 import com.micoyc.speakthat.PriorityAppAdapter;
 import com.micoyc.speakthat.R;
@@ -36,6 +37,7 @@ public class NotificationBehaviorSection implements BehaviorSettingsSection {
     private final List<String> priorityAppsList = new ArrayList<>();
     private PriorityAppAdapter priorityAppAdapter;
     private ActivityResultLauncher<Intent> priorityAppPickerLauncher;
+    private SwitchMaterial switchSkipRepeatedNotificationPrefixes;
 
     public NotificationBehaviorSection(
         AppCompatActivity activity,
@@ -66,6 +68,17 @@ public class NotificationBehaviorSection implements BehaviorSettingsSection {
                 }
             }
         );
+
+        switchSkipRepeatedNotificationPrefixes = binding.switchSkipRepeatedNotificationPrefixes;
+        switchSkipRepeatedNotificationPrefixes.setOnCheckedChangeListener((buttonView, isChecked) -> {
+            if (store.isInitializing()) {
+                return;
+            }
+            store.prefs().edit().putBoolean(
+                BehaviorSettingsStore.KEY_SKIP_REPEATED_NOTIFICATION_PREFIX,
+                isChecked
+            ).apply();
+        });
 
         binding.behaviorModeGroup.setOnCheckedChangeListener((group, checkedId) -> {
             String mode = "interrupt";
@@ -119,6 +132,12 @@ public class NotificationBehaviorSection implements BehaviorSettingsSection {
         priorityAppsList.addAll(priorityApps);
         priorityAppAdapter.notifyDataSetChanged();
         updatePriorityAppsSummary();
+
+        boolean skipRepeatedPrefix = store.prefs().getBoolean(
+            BehaviorSettingsStore.KEY_SKIP_REPEATED_NOTIFICATION_PREFIX,
+            BehaviorSettingsStore.DEFAULT_SKIP_REPEATED_NOTIFICATION_PREFIX
+        );
+        switchSkipRepeatedNotificationPrefixes.setChecked(skipRepeatedPrefix);
     }
 
     @Override

--- a/app/src/main/res/layout/activity_behavior_settings.xml
+++ b/app/src/main/res/layout/activity_behavior_settings.xml
@@ -74,6 +74,23 @@
                         android:textColor="@color/purple_card_text_secondary"
                         android:layout_marginBottom="8dp" />
 
+                    <com.google.android.material.switchmaterial.SwitchMaterial
+                        android:id="@+id/switchSkipRepeatedNotificationPrefixes"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/behavior_skip_repeated_prefix_title"
+                        android:textColor="@color/purple_card_text_primary"
+                        android:layout_marginBottom="4dp"
+                        app:useMaterialThemeColors="true" />
+
+                    <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="@string/behavior_skip_repeated_prefix_description"
+                        android:textSize="14sp"
+                        android:textColor="@color/purple_card_text_secondary"
+                        android:layout_marginBottom="16dp" />
+
                     <!-- Recommendation Box -->
                     <LinearLayout
                         android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -592,6 +592,8 @@ This feature is especially useful for accessibility, desk users, and anyone who 
     <string name="behavior_queue_mode">Queue (finish current, then read new)</string>
     <string name="behavior_skip_mode">Skip (ignore new notifications while reading)</string>
     <string name="behavior_smart_mode">Smart (priority apps interrupt, others queue)</string>
+    <string name="behavior_skip_repeated_prefix_title">Skip repeated notification prefixes</string>
+    <string name="behavior_skip_repeated_prefix_description">When enabled, consecutive notifications with the same starting words will drop the repeated prefix and only speak the new text.</string>
     <string name="behavior_priority_apps">⚡ Priority Apps</string>
     <string name="behavior_priority_apps_description">These apps will interrupt the current notification. All other apps will queue.</string>
     <string name="behavior_media_ignore">Ignore - Continue as normal</string>


### PR DESCRIPTION
I had AI implement this from https://github.com/mitchib1440/SpeakThat/issues/58#issuecomment-3797733794

> read the first full notification, then in consecutive ones will skip repeated parts, e.g. if the room or username is the same, then it just says the username, or if username is the same, just the message. Maybe something simple that can detect if the first few words of the format it reads is the same in consecutively-received notifications, it can skip those same first words.

Obviously needs some work (proper config option placement, update debug messages accordingly, etc.) but I'm curious what you think of this currently, since I know you have mentioned some other ideas for conditional rules and the like.