### PR TITLE
Fix: Prevent unsaved changes dialog during AppPicker loading

### DIFF
--- a/app/src/main/java/com/micoyc/speakthat/AppPickerActivity.kt
+++ b/app/src/main/java/com/micoyc/speakthat/AppPickerActivity.kt
@@ -101,7 +101,10 @@ class AppPickerActivity : AppCompatActivity(), AppFilterBottomSheetFragment.List
 
         onBackPressedDispatcher.addCallback(this, object : OnBackPressedCallback(true) {
             override fun handleOnBackPressed() {
-                if (hasUnsavedChanges()) {
+                if (isLoading) {
+                    setResult(RESULT_CANCELED)
+                    finish()
+                } else if (hasUnsavedChanges()) {
                     showUnsavedChangesDialog()
                 } else {
                     setResult(RESULT_CANCELED)


### PR DESCRIPTION
- Add isLoading check in back press handler
- Prevents dialog from showing when apps are still loading
- Fixes issue where pressing save during load clears existing selection